### PR TITLE
Feature: Soporte para URL con Fragment Text #24

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -1,29 +1,51 @@
 // Función para mostrar una notificación
 function showNotification(message) {
   chrome.notifications.create({
-    type: 'basic',
-    iconUrl: '../assets/icon.png', // Cambia esto al icono que prefieras
+    type: "basic",
+    iconUrl: "../assets/icon.png", // Cambia esto al icono que prefieras
     title: chrome.i18n.getMessage("ext_name"),
     message,
-    priority: 1
+    priority: 1,
   });
 }
 
 chrome.runtime.onInstalled.addListener(() => {
-    chrome.contextMenus.create({
-        id: "github.com.maximovj.QRTransferGo.share_by_qr",
-        title: chrome.i18n.getMessage("share_by_qr"),
-        contexts: ["selection", "link", "image", "page"]
-    });
+  chrome.contextMenus.create({
+    id: "github.com.maximovj.QRTransferGo.share_by_qr",
+    title: chrome.i18n.getMessage("share_by_qr"),
+    contexts: ["selection", "link", "image", "page"],
+  });
 
-    showNotification(chrome.i18n.getMessage("notification_1"));
+  showNotification(chrome.i18n.getMessage("notification_1"));
 });
 
 chrome.contextMenus.onClicked.addListener((info, tab) => {
   let qrData = "";
 
   if (info.selectionText) {
-    qrData = info.selectionText;
+    const text = info.selectionText.trim();
+
+    // Separar el texto en palabras
+    const words = text.split(/\s+/);
+
+    // Verificar si hay al menos 3 palabras al principio y 3 al final
+    if (words.length >= 6) {
+      // Obtener las primeras 3 palabras y las últimas 3 palabras
+      const firstWords = encodeURIComponent(words.slice(0, 3).join(" "));
+      const lastWords = encodeURIComponent(words.slice(-3).join(" "));
+
+      // Codificar para URL
+      const encodedText = `${firstWords},${lastWords}`;
+
+      // Eliminar cualquier `#:~:text=` existente en la URL
+      qrData = tab.url.split("#:~:text=")[0];
+
+      // Agregar el fragmento correctamente
+      qrData += `#:~:text=${encodedText}`;
+    } else {
+      // Si no hay suficientes palabras, usa el texto como qrData
+      qrData = info.selectionText;
+    }
   } else if (info.linkUrl) {
     qrData = info.linkUrl;
   } else if (info.srcUrl) {


### PR DESCRIPTION
La funcionalidad de Edge que permite resaltar y compartir fragmentos específicos de texto en una página web se llama "Fragment Text" o "Text Fragment Anchors".

Esta característica permite generar un enlace con un fragmento de texto resaltado, utilizando la sintaxis especial #:~:text= en la URL. Cuando alguien abre el enlace en un navegador compatible (como Edge o Chrome), la página se desplazará automáticamente hasta el fragmento de texto y lo resaltará.

- Modificar el archivo backgroun.js
- Agregar soporte para URL con Fragment Text 
```js
if (info.selectionText) {
    const text = info.selectionText.trim();
    
    // Separar el texto en palabras
    const words = text.split(/\s+/); 

    // Verificar si hay al menos 3 palabras al principio y 3 al final
    if (words.length >= 6) {
      // Obtener las primeras 3 palabras y las últimas 3 palabras
      const firstWords = encodeURIComponent(words.slice(0, 3).join(" "));
      const lastWords = encodeURIComponent(words.slice(-3).join(" "));
      
      // Codificar para URL
      const encodedText = `${firstWords},${lastWords}`;

      // Eliminar cualquier `#:~:text=` existente en la URL
      qrData = tab.url.split('#:~:text=')[0];

      // Agregar el fragmento correctamente
      qrData += `#:~:text=${encodedText}`;
    } else {
      // Si no hay suficientes palabras, usa el texto como qrData
      qrData = info.selectionText;
    }
  }
```